### PR TITLE
Correct Kore configuration.

### DIFF
--- a/benchmarks/kore/conf/kore.conf
+++ b/benchmarks/kore/conf/kore.conf
@@ -3,9 +3,12 @@
 bind		127.0.0.1 8080
 load		./kore.so
 tls_dhparam	dh2048.pem
-workers		12
+
+workers				12
 worker_max_connections		250
 worker_rlimit_nofiles		1024
+worker_accept_treshold		10
+worker_set_affinity		0
 
 domain localhost {
 	certfile	cert/server.crt

--- a/benchmarks/kore/conf/kore.conf
+++ b/benchmarks/kore/conf/kore.conf
@@ -7,7 +7,7 @@ tls_dhparam	dh2048.pem
 workers				12
 worker_max_connections		250
 worker_rlimit_nofiles		1024
-worker_accept_treshold		10
+worker_accept_threshold		10
 worker_set_affinity		0
 
 domain localhost {


### PR DESCRIPTION
Kore ran on a single worker in previous benchmarks.

This is due Kore by default accepting as many new connections
as it can. Considering the max connections was set to 250 and
the benchmark was run with 100 connections only this resulted
in only a single worker doing all the heavy lifting.

The new settings will limit workers their accept loop to
a maximum of 10 new connections at a time before giving
up on the accept lock so others can grab connections too.

Also kills setting affinity as the author decided to use
12 worker processes.
